### PR TITLE
Fix: Remove incorrect padding from JWK modulus in jwk_to_pem

### DIFF
--- a/sap/xssec/key_tools.py
+++ b/sap/xssec/key_tools.py
@@ -5,7 +5,6 @@ from jwt.algorithms import RSAAlgorithm
 
 
 def jwk_to_pem(jwk) -> str:
-    jwk["n"] = jwk["n"] + "=="  # avoid `incorrect padding`
     pubkey = RSAAlgorithm.from_jwk(json.dumps(jwk))
     pem = pubkey.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode()
     return pem


### PR DESCRIPTION
## Bug Description

The `jwk_to_pem` function in `sap/xssec/key_tools.py` was unconditionally appending '==' to the JWK modulus (n) parameter with the comment "avoid `incorrect padding`". This approach was fundamentally flawed because:

1. Base64url encoding in JWKs does not require manual padding manipulation
2. The padding characters are only needed when the encoded data length is not a multiple of 4
3. Unconditionally adding '==' corrupts the base64 value

## Impact

This bug caused RSA key reconstruction to fail or produce invalid keys when converting JWK to PEM format.

## Fix

Removed the problematic line that appended '==' to the modulus. The `RSAAlgorithm.from_jwk()` method from PyJWT handles proper base64url decoding internally, including any necessary padding.

## Testing

The fix should be validated by:
1. Converting a valid JWK to PEM format
2. Verifying the resulting PEM can be used for RSA operations
3. Ensuring the modulus value is correctly preserved

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.