### PR TITLE
security: harden GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: read-all
+
 jobs:
   build:
     permissions:
@@ -34,6 +36,7 @@ jobs:
           tox -e py${pythonVersion}
 
   deploy:
+    environment: pypi
     permissions:
       contents: read
     needs: build


### PR DESCRIPTION
## Summary

Addresses findings from the Supply Chain Risk Monitoring Dashboard for `github.com/SAP/cloud-pysec`:

- **Control 5** (Action Required): Add `permissions: read-all` at workflow level to set default workflow token to read-only — fixes the *[Orca/hazardous] Default Workflow Token Permission Should Be Set To Read Only* violation
- **Control 6** (Warning): Add `environment: pypi` to the `deploy` job to scope `PYPI_API_TOKEN` to a protected GitHub Environment — fixes the *main.yml: uses secrets (PYPI_API_TOKEN) without environment protection* violation

> **Note:** The `pypi` GitHub Environment has already been created in repository settings. The `PYPI_API_TOKEN` secret should be moved from repo-level to the `pypi` environment after this PR is merged.

## Test plan

- [ ] Verify CI build jobs pass
- [ ] Verify deploy job still runs on tag push
- [ ] Move `PYPI_API_TOKEN` secret to the `pypi` environment in Settings → Environments